### PR TITLE
Add +gfm parameter to support GitHub Flavored Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ curl -u user:password https://viaboxx.atlassian.net/wiki/rest/api/content/340827
 	+H true/false true: document hierarchy used to generate page header format type (child document => h2 etc) (default: true)
 	+T true/false true: title transformation ON (cut everything before first -) (default: true)
   	+RootPageTitle true/false true: generate header for root page, false: omit header of root page (default: true)
+  	+gfm true/false: generate GitHub Flavored Markdown (default: false) 
 
 ## Examples ##
 

--- a/src/main/groovy/de/viaboxx/markdown/Confluence2MD.groovy
+++ b/src/main/groovy/de/viaboxx/markdown/Confluence2MD.groovy
@@ -629,7 +629,7 @@ class Confluence2MD extends ConfluenceParser implements Walker {
         boolean isHeader = writeHeaderBeginTags(effectiveLevel)
         processor()
         writeHeaderEndTags(effectiveLevel)
-        if (ref && isHeader) writeRaw(" {#${ref}}")
+        if (ref && isHeader && !gfm)  writeRaw(" {#${ref}}")
         assertBlankLine()
     }
 
@@ -649,7 +649,11 @@ class Confluence2MD extends ConfluenceParser implements Walker {
     }
 
     protected boolean writeHeaderEndTags(int level) {
-        return writeHeaderTags(level)
+        if (gfm) {
+            return true;
+        } else {
+            return writeHeaderTags(level)
+        }
     }
 
     protected boolean writeHeaderTags(int level) {
@@ -658,6 +662,7 @@ class Confluence2MD extends ConfluenceParser implements Walker {
             return false
         } else {
             level.times { writeRaw('#') }
+            if (gfm) writeRaw(' ')
             return true
         }
     }

--- a/src/main/groovy/de/viaboxx/markdown/Confluence2MDArgsParser.groovy
+++ b/src/main/groovy/de/viaboxx/markdown/Confluence2MDArgsParser.groovy
@@ -110,6 +110,10 @@ class Confluence2MDArgsParser {
                     case "+RootPageTitle":
                         titleRootPage = Boolean.parseBoolean(args[++i])
                         break
+                    case "+gfm":
+                        log("Generating GFM format")
+                        gfm = true
+                        break
                 }
             }
             switch (format) {

--- a/src/main/groovy/de/viaboxx/markdown/ConfluenceParser.groovy
+++ b/src/main/groovy/de/viaboxx/markdown/ConfluenceParser.groovy
@@ -55,6 +55,7 @@ abstract class ConfluenceParser implements NodeHandler {
     protected boolean caching = true // file caching true or false
     protected Map pageIdCache = [:]  // key = page.title, value = page.id
     protected Map attachmentCache = [:] // key = page.id, value = attachments (jsonSlurper)
+    protected boolean gfm = false // GitHub flavoured markdown
 
     protected PlantUmlImageGenerator umlImageGenerator = new PlantUmlImageGenerator(this)
 

--- a/src/test/groovy/de/viaboxx/markdown/Confluence2MDTest.groovy
+++ b/src/test/groovy/de/viaboxx/markdown/Confluence2MDTest.groovy
@@ -39,15 +39,34 @@ class Confluence2MDTest extends Specification {
                 "|\n" +
                 "\n"
     }
-
     def xmlPanel() {
         when:
+        c2md.gfm = false;
         c2md.parseBody('<h2>Body</h2><ac:structured-macro ac:name=\"code\"><ac:parameter ac:name=\"\">xml</ac:parameter>' +
                 '<ac:plain-text-body><![CDATA[<ExecSetup taskId=\"some unique id\">\n  <target>c:\\vtouch\\cortex\\downl' +
                 'oads\\PREUPD.CMD</target>\n</ExecSetup>\n]]></ac:plain-text-body></ac:structured-macro>')
         then:
         markdown() ==
                 "###Body###\n" +
+                "\n" +
+                "\n" +
+                "\n" +
+                "~~~~~~~\n" +
+                "<ExecSetup taskId=\"some unique id\">\n" +
+                "  <target>c:\\vtouch\\cortex\\downloads\\PREUPD.CMD</target>\n" +
+                "</ExecSetup>\n" +
+                "\n" +
+                "~~~~~~~\n"
+    }
+    def GFMPage() {
+        when:
+        c2md.gfm = true;
+        c2md.parseBody('<h2>Body</h2><ac:structured-macro ac:name=\"code\"><ac:parameter ac:name=\"\">xml</ac:parameter>' +
+                '<ac:plain-text-body><![CDATA[<ExecSetup taskId=\"some unique id\">\n  <target>c:\\vtouch\\cortex\\downl' +
+                'oads\\PREUPD.CMD</target>\n</ExecSetup>\n]]></ac:plain-text-body></ac:structured-macro>')
+        then:
+        markdown() ==
+                "### Body\n" +
                 "\n" +
                 "\n" +
                 "\n" +


### PR DESCRIPTION
I found this project useful in converting some Confluence wiki pages to GitHub markdown.   Thanks for creating it.

I made a few changes to the source code to improve support for generating GitHub Flavored Markdown.   I added a +gfm to allow the end-user to choose whether to use this capability, or not, as well as a test case.   I'm sure more can be done to improve it but this got me most of the way there.